### PR TITLE
Add thread-safe build support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ env:
   RUNNER_OS_LIST: ubuntu-18.04 ubuntu-20.04 ubuntu-22.04
   PHP_LIST: 8.0 8.1 8.2 8.3
   SAPI_LIST: apache2 cgi cli embed fpm phpdbg
-  BUILD_LIST: debug release
+  BUILD_LIST: debug thread-safe release
 
 jobs:
   get-matrix:
@@ -196,7 +196,7 @@ jobs:
           php -v
           php -r "if(strpos(phpversion(), '${{ matrix.php-version }}') === false) {throw new Exception('Wrong PHP version Installed');}"
           php -m
-          
+
       - name: Check GD support
         run: php -r "print_r(gd_info());"
 

--- a/config/definitions/8.0
+++ b/config/definitions/8.0
@@ -126,6 +126,9 @@
 # Placeholder for debug build.
 DEBUG
 
+# Placeholder for thread-safe build.
+ZTS
+
 # Placeholder for patch commands.
 PATCHES
 

--- a/config/definitions/8.1
+++ b/config/definitions/8.1
@@ -126,6 +126,9 @@
 # Placeholder for debug build.
 DEBUG
 
+# Placeholder for thread-safe build.
+ZTS
+
 # Placeholder for patch commands.
 PATCHES
 

--- a/config/definitions/8.2
+++ b/config/definitions/8.2
@@ -126,6 +126,9 @@
 # Placeholder for debug build.
 DEBUG
 
+# Placeholder for thread-safe build.
+ZTS
+
 # Placeholder for patch commands.
 PATCHES
 

--- a/config/definitions/8.3
+++ b/config/definitions/8.3
@@ -126,6 +126,9 @@
 # Placeholder for debug build.
 DEBUG
 
+# Placeholder for thread-safe build.
+ZTS
+
 # Placeholder for patch commands.
 PATCHES
 

--- a/scripts/build_partials/php_build.sh
+++ b/scripts/build_partials/php_build.sh
@@ -37,10 +37,17 @@ configure_phpbuild() {
     debug='configure_option --enable-debug'
   fi
 
+  # Path the definition for thread-safe.
+  zts=''
+  if [ "${BUILD:?}" = "thread-safe" ]; then
+    zts='configure_option --enable-zts'
+  fi
+
   # Patch PHP version, host, build, patches and install command in the definition template.
   sed -i -e "s|BUILD_MACHINE_SYSTEM_TYPE|$(dpkg-architecture -q DEB_BUILD_GNU_TYPE)|" \
          -e "s|HOST_MACHINE_SYSTEM_TYPE|$(dpkg-architecture -q DEB_HOST_GNU_TYPE)|" \
          -e "s|DEBUG|$debug|" \
+         -e "s|ZTS|$zts|" \
          -e "s|INSTALL|$install_command|" \
          -e "s|PHP_VERSION|$PHP_VERSION|" \
          -e "s|PHP_VERSION|$PHP_VERSION|" \

--- a/scripts/install-requirements.sh
+++ b/scripts/install-requirements.sh
@@ -137,6 +137,11 @@ get_libmysql() {
   echo "$mysql"
 }
 
+if [ -z "${BUILD}" ]; then
+  echo "BUILD is not defined"
+  exit 1;
+fi
+
 # Constants.
 list_file='/etc/apt/sources.list'
 list_dir="$list_file.d"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,5 +1,14 @@
 #!/usr/bin/env bash
 
+# Function to print usage help
+print_help() {
+  cat << HELP > /dev/stdout
+
+Usage: ${0} [--remove] <php-version>
+
+HELP
+}
+
 get() {
   file_path=$1
   shift
@@ -259,7 +268,7 @@ install() {
   else
     github_deps &
     to_wait=($!)
-  fi  
+  fi
   tar_file="php_$version$PHP_PKG_SUFFIX+$ID$VERSION_ID.tar.zst"
   get "/tmp/$tar_file" "https://github.com/shivammathur/php-builder/releases/download/builds/$tar_file"
   sudo rm -rf /etc/php/"$version" /tmp/php"$version"
@@ -342,6 +351,12 @@ remove() {
   exit 0;
 }
 
+# avoid running without arguments
+if [[ "${#}" -eq 0 ]]; then
+  print_help
+  exit 0;
+fi
+
 if [[ "$1" =~ remove ]]; then
   version=$2
   remove
@@ -365,6 +380,7 @@ else
 fi
 build=${3:-release}
 [ "${build:?}" = "debug" ] && PHP_PKG_SUFFIX=-dbgsym
+[ "${build:?}" = "thread-safe" ] && PHP_PKG_SUFFIX="-zts"
 
 pecl_file="/etc/php/$version/mods-available/pecl.ini"
 list_file='/etc/apt/sources.list'


### PR DESCRIPTION
Following https://github.com/shivammathur/setup-php/issues/649, this PR adds a new build type: `thread-safe`, it uses the same approach as `debug` builds.

It also adds some sanity checks to `scripts/build.sh` and `scripts/install.sh`, to help identify missing variables/arguments before what would be an invalid execution.