### PR TITLE
PCOV: remove patch now in upstream

### DIFF
--- a/scripts/patch-extensions.sh
+++ b/scripts/patch-extensions.sh
@@ -60,8 +60,3 @@ patch_redis() {
 patch_igbinary() {
   [[ "$PHP_VERSION" = "8.3" || "$PHP_VERSION" = "8.4" || "$PHP_VERSION" = "8.5" ]] && find . -type f -exec sed -i 's/zend_uintptr_t/uintptr_t/g' {} +;
 }
-
-# Function to patch pcov source.
-patch_pcov() {
-	[[ "$PHP_VERSION" = "8.4" || "$PHP_VERSION" = "8.5" ]] && sed -i 's/0, 0, 0, 0/0, 0, 0/' pcov.c
-}


### PR DESCRIPTION
PCOV has now been patched and released upstream

https://github.com/krakjoe/pcov/compare/v1.0.11...v1.0.12#diff-b087107e80a8fa279b6a96f34cc65279ad1b664934a363966d8a63322e667be4